### PR TITLE
Fixed the plotting script for infection chain.

### DIFF
--- a/src/covid19sim/plotting/main.py
+++ b/src/covid19sim/plotting/main.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import hydra
 from omegaconf import OmegaConf
+import random
 
 import covid19sim.plotting.plot_jellybeans as jellybeans
 import covid19sim.plotting.plot_pareto_adoption as pareto_adoption
@@ -210,6 +211,8 @@ def main(conf):
                 "humans_rec_level",
             ]
         )
+    # Stop loading data for spy_human
+    '''
     if "spy_human" in plots:
         keep_pkl_keys.update(
             [
@@ -220,6 +223,7 @@ def main(conf):
                 "human_has_app",
             ]
         )
+    '''
     if "jellybeans" in plots:
         keep_pkl_keys.update(
             ["humans_intervention_level", "humans_rec_level", "intervention_day"]
@@ -296,7 +300,42 @@ def main(conf):
             # -------------------------------
             # -----  Run Plot Function  -----
             # -------------------------------
-            func(data, plot_path, conf["compare"], **options[plot])
+
+            # For plot other than spy_human, we use the loaded pkl files.
+            if plot != 'spy_human':
+                func(data, plot_path, conf["compare"], **options[plot])
+            # For spy_human, we randomly load a file to print.
+            else:
+                # Get all the methods.
+                method_path = Path(root_path).resolve()
+                assert method_path.exists()
+                methods = [
+                    m
+                    for m in method_path.iterdir()
+                    if m.is_dir()
+                    and not m.name.startswith(".")
+                    and len(list(m.glob("**/tracker*.pkl"))) > 0
+                ]
+
+                # For each method, load a random pkl file and plot the infection chains.
+                for m in methods:
+                    sm = str(m)
+                    runs = [
+                        r
+                        for r in m.iterdir()
+                        if r.is_dir()
+                        and not r.name.startswith(".")
+                        and len(list(r.glob("tracker*.pkl"))) == 1
+                    ]
+                    rand_index = random.randint(0, len(runs)-1)
+                    rand_run = runs[rand_index]
+
+                    with open(str(list(rand_run.glob("tracker*.pkl"))[0]), "rb") as f:
+                        pkl = pickle.load(f)
+
+                    func(dict([(m, pkl)]), plot_path, None, **options[plot])
+                print("Done.")
+
         except Exception as e:
             if isinstance(e, KeyboardInterrupt):
                 print("Interrupting.")
@@ -307,6 +346,7 @@ def main(conf):
                 print("*" * len(str(e)))
                 print("Ignoring " + plot)
         print_footer()
+
 
 
 if __name__ == "__main__":

--- a/src/covid19sim/plotting/plot_spy_human.py
+++ b/src/covid19sim/plotting/plot_spy_human.py
@@ -371,16 +371,19 @@ def run(data, path, comparison_key, wandb=False, num_chains=1):
     # Options:
     # 1. "num_chains" is an integer, specifying how many infection chains we want to generate.
 
-    label2pkls = list()
-    for method in data:
-        for key in data[method]:
-            label = f"{method}_{key}"
-            pkls = [r["pkl"] for r in data[method][key].values()]
-            label2pkls.append((label, pkls))
-
-    for label, pkls in label2pkls:
+    for method, pkl in data.items():
+        dir_path = (
+            path
+            / "infection_chain"
+        )
+        os.makedirs(dir_path, exist_ok=True)
         for k in range(num_chains):
-            rand_index = random.randint(0, len(pkls) - 1)
-            pkl = pkls[rand_index]
-            output_file = path / "spy_human" / f"infection_chain_{label}_chain:{k}.html"
-            plot(pkl, output_file)
+            if str(method)[-1] == '/':
+                m = str(method).split('/')[-2]
+            else:
+                m = str(method).split('/')[-1]
+            fig_path = os.path.join(dir_path, '{}_chain:{}.html'.format(m, k))
+
+            print(fig_path)
+            
+            plot(pkl, fig_path)


### PR DESCRIPTION
# Description

The plotting script for infection chain was fixed.

Now, the infection chain will be plotted in the following way:
1. For each method, randomly select a run.
2. Load only the pkl file of the selected run, rather than loading all the pkl files.
3. Plot the infection chain with the loaded pkl file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It was tested with my local pkl files.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
