### PR TITLE
Add a test on the total update messages received during a time slot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pyyaml
 pytest
 pytest-timeout
 pytest-cov==2.8.1
+pytest-subtests==0.3.1
 hydra-core==0.11
 omegaconf==1.4.1
 cached_property

--- a/tests/test_configs/mini_simulations.yaml
+++ b/tests/test_configs/mini_simulations.yaml
@@ -1,0 +1,204 @@
+---
+# EXPERIMENTAL PARAMETERS
+COLLECT_LOGS : True
+COLLECT_TRAINING_DATA : False
+USE_INFERENCE_SERVER : False
+RISK_MODEL : "transformer" # "naive", "manual", "digital", "transformer"
+INIT_PERCENT_SICK : 0.1
+SHOULD_MODIFY_BEHAVIOR : True
+USE_ORACLE : False
+
+## INTERVENTIONS
+INTERVENTION_DAY : 0
+INTERVENTION : "Tracing"
+DROPOUT_RATE: 0.02
+APP_UPTAKE : -1
+GLOBAL_MOBILITY_SCALING_FACTOR: .3
+
+# PATHS
+CLUSTER_PATH : "output/clusters.json"
+
+# Inference & Training
+TRACING_N_DAYS_HISTORY : 14
+DUMP_CLUSTERS : False
+CLUSTER_ALGO_TYPE: "blind" # should be in ["gaen", "blind"]
+RESET_INFERENCE_SERVER: True
+
+# TRACING RISK MODEL PARAMETERS  (non-ML)
+TRACE_SYMPTOMS : False
+TRACE_RISK_UPDATE : False
+TRACING_ORDER : 1
+UPDATES_PER_DAY : 4
+
+RISK_MAPPING :
+  [
+    0.0,
+    0.010190361,
+    0.022800818,
+    0.033924844,
+    0.044960417,
+    0.0564146,
+    0.069076724,
+    0.08331901,
+    0.09839013,
+    0.115344636,
+    0.13295256,
+    0.15386948,
+    0.1748018,
+    0.19909734,
+    0.22582635,
+    0.26276696,
+    1.0,
+  ]
+
+# The group age proportion (p) are taken from Statistics Canada
+# ref: https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1710000501
+# ref: https://www12.statcan.gc.ca/census-recensement/2011/as-sa/98-312-x/2011003/fig/fig3_4-4-eng.cfm
+# TODO: senior_residency should be adjusted w.r.t. to the actual number of people per bin to combine them.
+HUMAN_DISTRIBUTION: # this is parsed into tuple keys in utils.py/parse_configuration e.g. "0-10" => (0, 10)
+  {
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "1-10":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.0, 0.2, 0.25, 0.35, 0.2],
+            "senior_residency": 0.0,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.0, "school": 1.0, "others": 0.0, "retired": 0.0
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "11-20":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.00, 0.2, 0.55, 0.15, 0.1],
+            "senior_residency": 0.0,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.0, "school": 0.85, "others": 0.15, "retired": 0.0
+          },
+      },
+    "21-30":
+      {
+        "p": 1.0,
+        "residence_preference":
+          {
+            "house_size": [0.2, 0.3, 0.3, 0.1, 0.1],
+            "senior_residency": 0.0,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.06, "school": 0.02, "others": 0.92, "retired": 0.0
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "31-40":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.1, 0.3, 0.30, 0.10, 0.2],
+            "senior_residency": 0.0,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.06, "school": 0.02, "others": 0.92, "retired": 0.0
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "41-50":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.1, 0.4, 0.2, 0.2, 0.1],
+            "senior_residency": 0.0,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.06, "school": 0.02, "others": 0.92, "retired": 0.0
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "51-60":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.2, 0.6, 0.1, 0.05, 0.05],
+            "senior_residency": 0.0,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.06, "school": 0.02, "others": 0.92, "retired": 0.0
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "61-70":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.25, 0.6, 0.05, 0.05, 0.05],
+            "senior_residency": 0.009,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.01, "school": 0.01, "others": 0.68, "retired": 0.3
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "71-80":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.1, 0.6, 0.15, 0.05, 0.1],
+            "senior_residency": 0.07,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.01, "school": 0.0, "others": 0.04, "retired": 0.95
+          },
+      },
+    # Skip this age group to remove age differenciation filtering in Human.at()
+    "81-101":
+      {
+        "p": 0.0,
+        "residence_preference":
+          {
+            "house_size": [0.15, 0.5, 0.1, 0.15, 0.1],
+            "senior_residency": 0.4,
+          },
+        "profession_profile":
+          {
+            "healthcare": 0.0, "school": 0.0, "others": 0.0, "retired": 1.0
+          },
+      },
+  }
+
+# TESTING
+# capacity is proportion of population tested per day
+TEST_TYPES: { "lab": {
+        "capacity": 0,  # ! /!\ This is now a proportion of population, not an absolute (int) value
+        "time_to_result": {
+          "in-patient": 0.33, # days
+          "out-patient": 2.0, # verbal communication with H&A (find-source)
+          },
+        "P_FALSE_NEGATIVE": {
+            "days_since_exposure": [1, 4, 5, 8, 9, 21],
+            "rate": [1, 0.67, 0.38, 0.2, 0.21, 0.66],
+            }, # https://www.acc.org/latest-in-cardiology/journal-scans/2020/05/18/13/42/variation-in-false-negative-rate-of-reverse?utm_source=journalscan&utm_medium=email_newsletter&utm_campaign=journalscan&utm_content=20200521
+        "P_FALSE_POSITIVE": 0.00, # verbal communication with H&A (find-source)
+        "preference": 1, # TODO: preference might depend on symptoms
+      } }
+
+# Console logging (Conditional with COLLECT_LOGS)
+LOGGING_LEVEL: "DEBUG"

--- a/tests/test_functional_mini_simulations.py
+++ b/tests/test_functional_mini_simulations.py
@@ -1,0 +1,328 @@
+import datetime
+import os
+import pickle
+import typing
+import unittest
+import zipfile
+from collections import namedtuple
+from tempfile import TemporaryDirectory
+
+from tests.utils import get_test_conf
+
+from covid19sim.log.event import Event
+
+if typing.TYPE_CHECKING:
+    from covid19sim.human import Human
+    from covid19sim.inference.message_utils import UpdateMessage
+
+
+TEST_CONF_NAME = "mini_simulations.yaml"
+
+
+InterventionProps = namedtuple('InterventionProps',
+                               ['name', 'risk_model', 'tracing_order'])
+
+
+class ProxyEvent(Event):
+    conf = None
+
+    @staticmethod
+    def log_encounter(*args, **kwargs):
+        Event.log_encounter(*args, **kwargs)
+
+    @staticmethod
+    def log_encounter_messages(*args, **kwargs):
+        Event.log_encounter_messages(*args, **kwargs)
+
+    @staticmethod
+    def log_risk_update(*args, **kwargs):
+        Event.log_risk_update(*args, **kwargs)
+
+    @staticmethod
+    def log_exposed(*args, **kwargs):
+        Event.log_exposed(*args, **kwargs)
+
+    @staticmethod
+    def log_test(*args, **kwargs):
+        Event.log_test(*args, **kwargs)
+
+    @staticmethod
+    def log_daily(*args, **kwargs):
+        Event.log_daily(*args, **kwargs)
+
+    @staticmethod
+    def log_static_info(*args, **kwargs):
+        Event.log_static_info(*args, **kwargs)
+
+
+class MakeHumanAsMessageProxy:
+    def __init__(self, test_case: unittest.TestCase):
+        self.test_case = test_case
+        self._max_update_messages_count: typing.Dict["Human", typing.Dict["Human", int]] = None
+
+    def set_max_update_messages_count(
+            self,
+            max_update_messages_count: typing.Dict["Human", typing.Dict["Human", int]]):
+        self._max_update_messages_count = max_update_messages_count
+
+    def make_human_as_message(
+            self,
+            human,
+            personal_mailbox: typing.Dict[int, typing.List["UpdateMessage"]],
+            conf):
+
+        tc = self.test_case
+
+        now = human.env.timestamp
+
+        update_messages_count: typing.Dict[str, int] = {}
+        for update_messages in personal_mailbox.values():
+            for update_message in update_messages:
+                update_messages_count.setdefault(update_message._sender_uid, 0)
+                update_messages_count[update_message._sender_uid] += 1
+
+        for sender_human, max_messages_count in self._max_update_messages_count[human].items():
+            update_messages_count.setdefault(sender_human.name, 0)
+            with tc.subTest(human=human.name, sender_human=sender_human.name,
+                            time=str(now),
+                            update_messages_count=update_messages_count[sender_human.name],
+                            max_update_messages_count=max_messages_count):
+                tc.assertLessEqual(update_messages_count[sender_human.name],
+                                   max_messages_count,
+                                   f"Human must not send more update messages "
+                                   f"than the total number of encounter messages")
+            del update_messages_count[sender_human.name]
+
+        tc.assertEqual(len(update_messages_count), 0,
+                       f"Update messages sent by other humans with no previous encounters"
+                       f"should not have been received")
+
+        message = MessagingTest.make_human_as_message(human, personal_mailbox, conf)
+
+        return message
+
+
+class TrackerMock:
+    def track_tested_results(self, *args, **kwargs):
+        pass
+
+
+def _init_infector(human):
+    # Force carefulness to 1 for the human to report the test result
+    human.carefulness = 1
+    # Force has_app to True for the human to report the test result
+    human.has_app = True
+    try:
+        if human.city.tracker is None:
+            human.city.tracker = TrackerMock()
+    except AttributeError:
+        human.city.tracker = TrackerMock()
+    # Make the human at his most infectious (Peak viral load day)
+    human._infection_timestamp = human.infection_timestamp + \
+                                 datetime.timedelta(days=-(human.viral_load_peak_start +
+                                                           human.infectiousness_onset_days))
+    # Mark the human as tested
+    human.set_test_info("lab", "positive")
+    # Make the test available now
+    human.time_to_test_result = 0
+
+    # Mock Human.how_am_I_feeling() to prevent human from staying at home
+    human.how_am_I_feeling = lambda: 1.0
+
+
+def _run_simulation(test_case, intervention_properties):
+    from covid19sim.run import simulate
+
+    intervention, risk_model, tracing_order = intervention_properties
+    test_case.config['INTERVENTION'] = intervention
+    test_case.config['RISK_MODEL'] = risk_model
+    test_case.config['TRACING_ORDER'] = tracing_order
+
+    if intervention == '':
+        test_case.config['INTERVENTION_DAY'] = -1
+    else:
+        test_case.config['INTERVENTION_DAY'] = test_case.intervention_day
+
+    data = []
+
+    with TemporaryDirectory() as d:
+        outfile = os.path.join(d, "data")
+        monitors, _ = simulate(
+            n_people=test_case.n_people,
+            start_time=test_case.start_time,
+            simulation_days=test_case.simulation_days,
+            outfile=outfile,
+            out_chunk_size=0,
+            init_percent_sick=test_case.init_percent_sick,
+            seed=test_case.test_seed,
+            conf=test_case.config
+        )
+        monitors[0].dump()
+        monitors[0].join_iothread()
+
+        with zipfile.ZipFile(f"{outfile}.zip", 'r') as zf:
+            for pkl in zf.namelist():
+                pkl_bytes = zf.read(pkl)
+                data.extend(pickle.loads(pkl_bytes))
+
+    test_case.assertGreater(len(data), 0)
+
+    test_case.assertIn(Event.encounter, {d['event_type'] for d in data})
+    test_case.assertIn(Event.test, {d['event_type'] for d in data})
+
+    test_case.assertGreaterEqual(len({d['human_id'] for d in data}), test_case.n_people)
+
+    return data
+
+
+class MiniSimulationTest(unittest.TestCase):
+    from covid19sim.log.event import Event
+
+    def setUp(self):
+        import covid19sim.log.event
+        covid19sim.log.event.Event = ProxyEvent
+
+        self.config = get_test_conf(TEST_CONF_NAME)
+        ProxyEvent.conf = self.config
+
+        self.test_seed = 0
+        self.n_people = 10
+        self.init_percent_sick = 0.1
+        self.start_time = datetime.datetime(2020, 2, 28, 0, 0)
+        self.simulation_days = 5
+        self.intervention_day = 0
+
+        self.config['COLLECT_LOGS'] = True
+        self.config['INTERVENTION_DAY'] = self.intervention_day
+        self.config['APP_UPTAKE'] = -1
+        self.config['TRANSFORMER_EXP_PATH'] = "https://drive.google.com/file/d/1QhiZehbxNOhA-7n37h6XEHTORIXweXc6"
+        self.config['LOGGING_LEVEL'] = "DEBUG"
+
+    def tearDown(self):
+        import covid19sim.log.event
+        covid19sim.log.event.Event = MiniSimulationTest.Event
+
+
+class MessagingTest(MiniSimulationTest):
+    from covid19sim.inference.heavy_jobs import make_human_as_message
+
+    def setUp(self):
+        super(MessagingTest, self).setUp()
+
+        from covid19sim.inference import heavy_jobs
+
+        # Prevent quarantines, we want to test contacts and messages
+        self.config["DROPOUT_RATE"] = 1.0
+
+        proxy = MakeHumanAsMessageProxy(self)
+        self.make_human_as_message_proxy = proxy
+        heavy_jobs.make_human_as_message = proxy.make_human_as_message
+
+    def tearDown(self):
+        super(MessagingTest, self).tearDown()
+
+        from covid19sim.inference import heavy_jobs
+
+        heavy_jobs.make_human_as_message = MessagingTest.make_human_as_message
+
+    def test_transformer(self):
+        """
+        Test the messaging system when using 1st order binary tracing
+        """
+        intervention = InterventionProps('Tracing', 'transformer', None)
+
+        initial_infectors = set()
+
+        # Holds human's encounter messages sent to other human count
+        time_slot_encounter_messages_cnt: typing.Dict["Human", typing.Dict["Human", int]] = {}
+        # Holds human's updates messages received from other human count
+        max_update_messages_cnt: typing.Dict["Human", typing.Dict["Human", int]] = {}
+        # Staged update messages to be received at the beginning of the next time slot
+        staged_max_update_messages_cnt: typing.Dict["Human", typing.Dict["Human", int]] = {}
+
+        self.make_human_as_message_proxy.set_max_update_messages_count(staged_max_update_messages_cnt)
+
+        def log_encounter_messages_proxy(COLLECT_LOGS, human1, human2, location, duration, distance, time):
+            Event.log_encounter_messages(COLLECT_LOGS, human1, human2, location, duration, distance, time)
+
+            time_slot_encounter_messages_cnt[human1].setdefault(human2, 0)
+            time_slot_encounter_messages_cnt[human2].setdefault(human1, 0)
+
+            messages_count = duration / human1.conf.get("MIN_MESSAGE_PASSING_DURATION")
+            time_slot_encounter_messages_cnt[human1][human2] += int(messages_count)
+            time_slot_encounter_messages_cnt[human2][human1] += int(messages_count)
+
+        def log_risk_update_proxy(COLLECT_LOGS, human, tracing_description,
+                                  prev_risk_history_map, risk_history_map, current_day_idx,
+                                  time):
+            Event.log_risk_update(COLLECT_LOGS, human, tracing_description,
+                                  prev_risk_history_map, risk_history_map, current_day_idx,
+                                  time)
+
+            h_ts_encounter_messages_cnt = time_slot_encounter_messages_cnt[human]
+
+            # Reset the count of update messages to be received by this human at
+            # the beginning of the next time slot
+            for other_human_staged_max_update_messages_cnt in staged_max_update_messages_cnt.values():
+                other_human_staged_max_update_messages_cnt[human] = 0
+
+            # The maximum update messages that can be received from this human
+            # is the sum of all encounter messages between him and another human.
+            # This could only be reached if the human sending has to update his
+            # risk level for all previous days and no other filtering on the
+            # updates messages is applied
+            for other_human, messages_count in h_ts_encounter_messages_cnt.items():
+                max_update_messages_cnt[other_human].setdefault(human, 0)
+                max_update_messages_cnt[other_human][human] += messages_count
+
+            is_new_risk_level = False
+            for prev_risk, risk in zip(prev_risk_history_map.values(), risk_history_map.values()):
+                prev_risk_level = min(human.proba_to_risk_level_map(prev_risk), 15)
+                risk_level = min(human.proba_to_risk_level_map(risk), 15)
+                is_new_risk_level = prev_risk_level != risk_level
+                if is_new_risk_level:
+                    break
+
+            if is_new_risk_level:
+                # Add all previous messages count in the max update messages
+                # count received by the other humans
+                for other_human in max_update_messages_cnt:
+                    max_update_messages_cnt[other_human].setdefault(human, 0)
+                    staged_max_update_messages_cnt[other_human][human] = max_update_messages_cnt[other_human][human]
+            else:
+                # Only the new encounter messages should count in the max update
+                # messages count received by the other humans
+                for other_human, messages_count in h_ts_encounter_messages_cnt.items():
+                    staged_max_update_messages_cnt[other_human][human] = messages_count
+
+            h_ts_encounter_messages_cnt.clear()
+
+        def log_static_info_proxy(*args, **kwargs):
+            from covid19sim.human import Human
+
+            Event.log_static_info(*args, **kwargs)
+            human = kwargs.get('human', None)
+            for arg in args:
+                if isinstance(arg, Human):
+                    human = arg
+                    break
+
+            self.assertIsNot(human, None)
+
+            # add human to list of initial_infectors
+            if human.is_exposed:
+                _init_infector(human)
+                initial_infectors.add(human)
+
+            time_slot_encounter_messages_cnt.setdefault(human, dict())
+            max_update_messages_cnt.setdefault(human, dict())
+            staged_max_update_messages_cnt.setdefault(human, dict())
+
+        ProxyEvent.log_encounter_messages = log_encounter_messages_proxy
+        ProxyEvent.log_risk_update = log_risk_update_proxy
+        ProxyEvent.log_static_info = log_static_info_proxy
+
+        _run_simulation(self, intervention)
+
+        # We want to test with only 1 initial infector
+        self.assertEqual(1, len(initial_infectors))


### PR DESCRIPTION
Originally: PR #121 on COVI-Canada. Opened by @satyaog on 2020/06/25.

Original description copied verbatim below:

# Description

Add a test on the total update messages received for a time slot

There should not be more update messages received from a sender than the number of new encounters in the time slot or the cumulative number of encounters if the sender has updated his risk level

## Type of change

Please delete options that are not relevant.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `pytest tests/`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes